### PR TITLE
Trainer refer error

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject postagga "0.2.8"
+(defproject postagga "0.2.9-SNAPSHOT"
   :description "A Library to parse natural language in pure Clojure and ClojureScript"
 
   :url "http://fekr.tech/postagga"

--- a/src/postagga/tools.cljc
+++ b/src/postagga/tools.cljc
@@ -1,6 +1,7 @@
 ;; Copyright(c) 2017 - [Rafik Naccache](rafik@fekr.tech)
 (ns postagga.tools
-  #?(:clj (:require [clojure.edn :as edn])))
+  (:require #?(:clj [clojure.edn :as edn])
+            clojure.set))
 
 (defn get-column
   "Given a matrix represented by a map {[i j] x}, produces the column such as j = column  "
@@ -65,4 +66,3 @@
           [file]
           (let [file-str (load-file-as-str file)]
             (edn/read-string file-str))))
-  

--- a/src/postagga/trainer.cljc
+++ b/src/postagga/trainer.cljc
@@ -11,10 +11,10 @@
 ;; transition matrix - given a state, how likely are we transition to the next one:
 #_{["P" "V"] 0.8 ["V" "D"] 0.1}
 ;; emission matrix - given a state, how likely are we going to see this obseravtion for it:
-#_{["P" "il"] 1 ["V" "mange"] 1} 
+#_{["P" "il"] 1 ["V" "mange"] 1}
 
 (ns postagga.trainer
-  (:require [postagga.tools :refer [get-row load-edn-from-resource]]))
+  (:require [postagga.tools :refer [get-row]]))
 
 (defn process-annotated-sentence
   " A sentence is [[Je P]] ... "


### PR DESCRIPTION
Removed a `:refer` to `postagga.tools/load-edn-from-resource`, which does not exist, and was not used in the NS.

To get the tests to pass, also added an explicit requirement for `clojure.set` in `postagga.tools`.