### PR TITLE
Bugfix/declaration order

### DIFF
--- a/src/postagga/parser.cljc
+++ b/src/postagga/parser.cljc
@@ -23,8 +23,6 @@
    (keyword? item)))
 
 
-(declare fast-forward-all-ors)
-
 (defn accept-tag
   "Verifies if an input like: [product NPP] correponds to
   one of the keys stored in the head of tag-stack, which would be an


### PR DESCRIPTION
I wasn't able to load the postagga.parser namespace because fast-foward was being referenced before declaration. I've moved fast-forward-all-ors and removed the unnecessary declare. 