### PR TITLE
Unit tests for utils and small improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pom.xml.asc
 .hgignore
 .hg/
 *~
+*.swp

--- a/src/postagga/parser.cljc
+++ b/src/postagga/parser.cljc
@@ -24,6 +24,7 @@
 
 
 (declare fast-forward-all-ors)
+(declare fast-forward)
 
 (defn accept-tag
   "Verifies if an input like: [product NPP] correponds to

--- a/src/postagga/tools.cljc
+++ b/src/postagga/tools.cljc
@@ -11,7 +11,7 @@
        (into {})))
 
 (defn get-row
-  "Given a matrix represented by a map {[i j] x}, produces the column such as j = column  "
+  "Given a matrix represented by a map {[i j] x}, produces the row such as i = row  "
   [matrix row]
   (->> matrix
        (filter #(= (get (key %) 0) row))

--- a/src/postagga/tools.cljc
+++ b/src/postagga/tools.cljc
@@ -20,7 +20,7 @@
 (defn arg-max
   "gives the key that yields the maximum value"
   [coll]
-  (apply max-key (into [coll] (keys coll))))
+  (apply max-key (into [coll] (or (keys coll) [nil]))))
 
 
 

--- a/test/postagga/core_test.cljc
+++ b/test/postagga/core_test.cljc
@@ -143,7 +143,7 @@
 
 
 (deftest sample-rules-pass
-  (testing "Je tue une mouche doit retourner P V D N")
+  (testing "Je tue une pomme doit retourner P V D N")
   (is (= {:sujet["Je"] :action ["tue"], :objet ["pomme"]}
          (-> (parse-tags-rules sample-tokenizer-fn sample-pos-tagger-fn  sample-rules "Je tue une pomme")
              (get-in [:result :data])))))

--- a/test/postagga/utils_test.cljc
+++ b/test/postagga/utils_test.cljc
@@ -25,3 +25,11 @@
   (is (= 1/3 (similarity "ab" "abcd")))
   (is (= 0 (similarity "ab" "cd"))))
 
+(deftest are-close-within-test
+  (testing "Are Close Within?")
+  (is (= false (are-close-within? 1/4 "ab" "cd")))  
+  (is (= true (are-close-within? 0 "ab" "cd")))  
+  (is (= false (are-close-within? 3/4 "abc" "bcd")))  
+  (is (= true (are-close-within? 1/4 "abc" "bcd")))  
+  (is (= true (are-close-within? 1 "abc" "abc"))))
+ 

--- a/test/postagga/utils_test.cljc
+++ b/test/postagga/utils_test.cljc
@@ -12,4 +12,16 @@
   (is (= #{"ab"} (bigrams "ab")))
   (is (= #{"ab" "bc"} (bigrams "abc"))))
 
+(deftest similarity-test
+  (testing "Similarity")
+  (is (= 0 (similarity nil nil)))  ; TODO: should this really be the case
+  (is (= 0 (similarity "" "")))    ; TODO: should this really be the case
+  (is (= 0 (similarity "" nil)))
+  (is (= 0 (similarity "a" nil)))
+  (is (= 0 (similarity "a" "")))
+  (is (= 0 (similarity "a" "a")))   ; TODO: should this really be the case???
+  (is (= 1 (similarity "ab" "ab")))
+  (is (= 1/2 (similarity "ab" "abc")))
+  (is (= 1/3 (similarity "ab" "abcd")))
+  (is (= 0 (similarity "ab" "cd"))))
 

--- a/test/postagga/utils_test.cljc
+++ b/test/postagga/utils_test.cljc
@@ -1,0 +1,11 @@
+;;Copyright (c) 2017 Rafik Naccache <rafik@fekr.tech>
+;;Distributed under the MIT License
+(ns postagga.utils-test
+  (:require [clojure.test :refer :all]
+            [postagga.tools :refer :all]))
+
+(deftest bigrams-test
+  (testing "Bigrams")
+  (is (= #{} (bigrams nil))))
+
+

--- a/test/postagga/utils_test.cljc
+++ b/test/postagga/utils_test.cljc
@@ -6,6 +6,10 @@
 
 (deftest bigrams-test
   (testing "Bigrams")
-  (is (= #{} (bigrams nil))))
+  (is (= #{} (bigrams nil)))
+  (is (= #{} (bigrams "")))
+  (is (= #{} (bigrams "a")))
+  (is (= #{"ab"} (bigrams "ab")))
+  (is (= #{"ab" "bc"} (bigrams "abc"))))
 
 

--- a/test/postagga/utils_test.cljc
+++ b/test/postagga/utils_test.cljc
@@ -13,6 +13,16 @@
   (is (= {} (get-column {[0 0] 1 [1 0] 2} 1)))
   (is (= {[0 1] 3 [1 1] 4} (get-column {[0 0] 1 [1 0] 2 [0 1] 3 [1 1] 4} 1)))
   (is (= {[0 0] 1 [2 0] 2} (get-column {[0 0] 1 [2 0] 2} 0))))
+
+(deftest get-row-test
+  (testing "Get Row")
+  (is (= {} (get-row nil 0)))
+  (is (= {} (get-row {} 0)))
+  (is (= {[0 0] 1} (get-row {[0 0] 1} 0)))
+  (is (= {[0 0] 1 [0 1] 2} (get-row {[0 0] 1 [0 1] 2} 0)))
+  (is (= {} (get-row {[0 0] 1 [0 1] 2} 1)))
+  (is (= {[1 0] 2 [1 1] 4} (get-row {[0 0] 1 [1 0] 2 [0 1] 3 [1 1] 4} 1)))
+  (is (= {[0 0] 1 [0 2] 2} (get-row {[0 0] 1 [0 2] 2} 0))))
  
 (deftest bigrams-test
   (testing "Bigrams")

--- a/test/postagga/utils_test.cljc
+++ b/test/postagga/utils_test.cljc
@@ -23,7 +23,13 @@
   (is (= {} (get-row {[0 0] 1 [0 1] 2} 1)))
   (is (= {[1 0] 2 [1 1] 4} (get-row {[0 0] 1 [1 0] 2 [0 1] 3 [1 1] 4} 1)))
   (is (= {[0 0] 1 [0 2] 2} (get-row {[0 0] 1 [0 2] 2} 0))))
- 
+
+(deftest arg-max-test
+  (testing "Arg Max")
+  ; (is (= nil (arg-max {})))    ; TODO: throws exeption
+  (is (= 0 (arg-max {0 0}))) 
+  (is (= 2 (arg-max {0 1 2 3})))) 
+
 (deftest bigrams-test
   (testing "Bigrams")
   (is (= #{} (bigrams nil)))

--- a/test/postagga/utils_test.cljc
+++ b/test/postagga/utils_test.cljc
@@ -4,6 +4,16 @@
   (:require [clojure.test :refer :all]
             [postagga.tools :refer :all]))
 
+(deftest get-column-test
+  (testing "Get Column")
+  (is (= {} (get-column nil 0)))
+  (is (= {} (get-column {} 0)))
+  (is (= {[0 0] 1} (get-column {[0 0] 1} 0)))
+  (is (= {[0 0] 1 [1 0] 2} (get-column {[0 0] 1 [1 0] 2} 0)))
+  (is (= {} (get-column {[0 0] 1 [1 0] 2} 1)))
+  (is (= {[0 1] 3 [1 1] 4} (get-column {[0 0] 1 [1 0] 2 [0 1] 3 [1 1] 4} 1)))
+  (is (= {[0 0] 1 [2 0] 2} (get-column {[0 0] 1 [2 0] 2} 0))))
+ 
 (deftest bigrams-test
   (testing "Bigrams")
   (is (= #{} (bigrams nil)))

--- a/test/postagga/utils_test.cljc
+++ b/test/postagga/utils_test.cljc
@@ -33,3 +33,10 @@
   (is (= true (are-close-within? 1/4 "abc" "bcd")))  
   (is (= true (are-close-within? 1 "abc" "abc"))))
  
+(deftest find-first-test
+  (testing "Find first")
+  (is (= nil (find-first #(= % 2) nil )))
+  (is (= nil (find-first #(= % 2) [1] )))
+  (is (= 2 (find-first #(= % 2) [1 2 3 4] )))
+  (is (= 5 (find-first #(= 0 (mod % 5)) [5 10] )))) 
+

--- a/test/postagga/utils_test.cljc
+++ b/test/postagga/utils_test.cljc
@@ -26,7 +26,7 @@
 
 (deftest arg-max-test
   (testing "Arg Max")
-  ; (is (= nil (arg-max {})))    ; TODO: throws exeption
+  (is (= nil (arg-max {})))
   (is (= 0 (arg-max {0 0}))) 
   (is (= 2 (arg-max {0 1 2 3})))) 
 


### PR DESCRIPTION
- Added `test/postagga/utils_test.cljc`, which contains unit tests for the methods of utils
- Fixed an edge-case for `arg-max` (on empty collection it threw an exception, now it returns `nil`)
- Corrected some typos in the doc-strings
- Added forward declaration of `fast-forward-all-ors` and `fast-forward` to make the code compile.